### PR TITLE
Fix issue with using file name

### DIFF
--- a/src/main/kotlin/no/eirikb/avatest/actions/AvaJavaScriptTestRunnerRunConfigurationGenerator.kt
+++ b/src/main/kotlin/no/eirikb/avatest/actions/AvaJavaScriptTestRunnerRunConfigurationGenerator.kt
@@ -35,11 +35,11 @@ class AvaJavaScriptTestRunnerRunConfigurationGenerator : AnAction() {
     }
 
     private fun getTestName(element: PsiElement?): String? {
-        if (element == null ||  element.parent== null) {
+        if (element == null || element.parent == null) {
             return null
         }
 
-        if( element !is JSCallExpression ){
+        if (element !is JSCallExpression) {
             return getTestName(element.parent)
         }
 
@@ -78,7 +78,7 @@ class AvaJavaScriptTestRunnerRunConfigurationGenerator : AnAction() {
         val filePath = currentFile.path
         val fileName = Paths.get(filePath).fileName.toString()
         val basePath = project.basePath
-        val relPath = if (basePath == null) fileName else currentFile.path.substring(basePath.length +1)
+        val relPath = if (basePath == null) fileName else currentFile.path.substring(basePath.length + 1)
         val node: NodeJsRunConfiguration? =
             NodeJsRunConfiguration.getDefaultRunConfiguration(project)?.clone() as NodeJsRunConfiguration?
         if (node == null) {

--- a/src/main/kotlin/no/eirikb/avatest/actions/AvaJavaScriptTestRunnerRunConfigurationGenerator.kt
+++ b/src/main/kotlin/no/eirikb/avatest/actions/AvaJavaScriptTestRunnerRunConfigurationGenerator.kt
@@ -6,7 +6,6 @@ import com.intellij.execution.configurations.ConfigurationFactory
 import com.intellij.execution.executors.DefaultRunExecutor
 import com.intellij.execution.runners.ExecutionUtil
 import com.intellij.lang.javascript.psi.JSCallExpression
-import com.intellij.lang.javascript.psi.JSElement
 import com.intellij.lang.javascript.psi.JSExpression
 import com.intellij.lang.javascript.psi.JSLiteralExpression
 import com.intellij.notification.Notification


### PR DESCRIPTION
Fixes an issue where the file name was used for ava, which would not work when the file is not in the current project root. This change uses the relative path to the file from the project root.

 I also added a fix to the test name search, as that was not working for me.