### PR TITLE
ci(release): support auto modify version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,11 @@
 
 name: Release
 on:
+  workflow_dispatch:
+    inputs:
+      version:
+        required: true
+        description: 'Version'
   release:
     types: [prereleased, released]
 
@@ -25,6 +30,11 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: ${{ github.event.release.tag_name }}
+
+      - name: Change Version
+        env:
+          VERSION: ${{ github.event.inputs.version }}
+        run: ./scripts/change-version-by-input.sh
 
       # Publish the plugin to the Marketplace
       - name: Publish Plugin
@@ -51,6 +61,11 @@ jobs:
         with:
           ref: ${{ github.event.release.tag_name }}
 
+      - name: Change Version
+        env:
+          VERSION: ${{ github.event.inputs.version }}
+        run: ./scripts/change-version-by-input.sh
+
       # Update Unreleased section with the current version
       - name: Patch Changelog
         run: ./gradlew patchChangelog
@@ -60,7 +75,7 @@ jobs:
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          git commit -m "Update changelog" -a
+          git commit -m "Update changelog and version" -a
 
       # Push changes
       - name: Push changes

--- a/scripts/change-version-by-input.sh
+++ b/scripts/change-version-by-input.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+PROJECT_FOLDER=$(
+  cd "$(dirname "$0")/.."
+  pwd
+)
+
+gsed -i "s/pluginVersion = .*/pluginVersion = $VERSION/" "$PROJECT_FOLDER/gradle.properties"


### PR DESCRIPTION
see: https://github.com/eirikb/AvaJavaScriptTestRunnerRunConfigurationGenerator/pull/34

I haven't actually tested this change, but I can assure you that the shell script is fine, i can't test the _action_ changes, but the syntax is fine.

If there is a problem with the later release, you can at me, or send me an email and I will assist.