### PR TITLE
Add support for AVA4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 
 pluginGroup = no.eirikb.avatest
 pluginName = AvaJavaScriptTestRunnerRunConfigurationGenerator
-pluginVersion = 1.5.0
+pluginVersion = 1.6.0
 pluginSinceBuild = 202
 pluginUntilBuild = 212.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl

--- a/src/main/kotlin/no/eirikb/avatest/actions/AvaJavaScriptTestRunnerRunConfigurationGenerator.kt
+++ b/src/main/kotlin/no/eirikb/avatest/actions/AvaJavaScriptTestRunnerRunConfigurationGenerator.kt
@@ -157,10 +157,9 @@ class AvaJavaScriptTestRunnerRunConfigurationGenerator : AnAction() {
             if (node.inputPath == null) {
                 val projectDir = project.guessProjectDir()
                 node.inputPath = listOf(
-                    "node_modules/ava/cli.js",
-                    "node_modules/.bin/ava.cmd",
-                    "node_modules/.bin/ava"
-                ).find { projectDir?.findFileByRelativePath(it) != null }
+                    "node_modules/ava/entrypoints/cli.mjs",
+                    "node_modules/ava/cli.js"
+                ).find { projectDir?.findFileByRelativePath(it)?.exists() == true }
             }
             node.name = getConfigurationName(fileName, testName)
             node.applicationParameters = getRunArguments(relPath, testName)

--- a/src/main/kotlin/no/eirikb/avatest/actions/AvaJavaScriptTestRunnerRunConfigurationGenerator.kt
+++ b/src/main/kotlin/no/eirikb/avatest/actions/AvaJavaScriptTestRunnerRunConfigurationGenerator.kt
@@ -22,6 +22,7 @@ import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.actionSystem.PlatformDataKeys
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.guessProjectDir
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.wm.ToolWindowId
 import com.intellij.psi.PsiElement
@@ -153,6 +154,14 @@ class AvaJavaScriptTestRunnerRunConfigurationGenerator : AnAction() {
             }
             node.workingDirectory = project.basePath
             node.inputPath = AppSettingsState.inputPath
+            if (node.inputPath == null) {
+                val projectDir = project.guessProjectDir()
+                node.inputPath = listOf(
+                    "node_modules/ava/cli.js",
+                    "node_modules/.bin/ava.cmd",
+                    "node_modules/.bin/ava"
+                ).find { projectDir?.findFileByRelativePath(it) != null }
+            }
             node.name = getConfigurationName(fileName, testName)
             node.applicationParameters = getRunArguments(relPath, testName)
 

--- a/src/main/kotlin/no/eirikb/avatest/settings/AppSettingsComponent.kt
+++ b/src/main/kotlin/no/eirikb/avatest/settings/AppSettingsComponent.kt
@@ -14,7 +14,7 @@ const val MARGIN_BOTTOM = 8
 class AppSettingsComponent {
     val panel: JPanel
     val myInputPathText = JBTextField()
-    var inputPathText: String
+    var inputPathText: String?
         get() = myInputPathText.text
         set(newText) {
             myInputPathText.text = newText

--- a/src/main/kotlin/no/eirikb/avatest/settings/AppSettingsState.kt
+++ b/src/main/kotlin/no/eirikb/avatest/settings/AppSettingsState.kt
@@ -7,7 +7,7 @@ import com.intellij.util.xmlb.XmlSerializerUtil
 
 @State(name = "no.eirikb.avatest.settings.AppSettingsState", storages = [Storage("SdkSettingsPlugin.xml")])
 object AppSettingsState : PersistentStateComponent<AppSettingsState?> {
-    var inputPath = "node_modules/ava/cli.js"
+    var inputPath: String? = null
     var selectedCommand = true
     var npmScriptsText = ""
 


### PR DESCRIPTION
The cli.js-file have been moved to lib-folder, but it doesn't work as before.
I'm not 100% sure why the file was targeted instead of the .bin-one,
could have been as simple as not having to deal with .cmd in windows.
Anyway, here comes a new solution; pick the first of these:
  1. node_modules/ava/cli.js
  2. node_modules/.bin/ava.cmd
  3. node_modules/.bin/ava

I haven't tested the .cmd one, as I don't have Windows here at the moment.
Also had to tweak the settings, hope it doesn't break.