### PR TITLE
108 plugin doesnt properly support tests with trailing spaces

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # -> https://plugins.jetbrains.com/docs/intellij/intellij-artifacts.html
 pluginGroup=no.eirikb.avatest
 pluginName=AvaJavaScriptTestRunnerRunConfigurationGenerator
-pluginVersion=1.11.0
+pluginVersion=1.12.0
 pluginSinceBuild=203
 pluginUntilBuild=231.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl

--- a/src/main/kotlin/no/eirikb/avatest/utils/getTestNameByClearUnnecessaryString.kt
+++ b/src/main/kotlin/no/eirikb/avatest/utils/getTestNameByClearUnnecessaryString.kt
@@ -12,7 +12,7 @@ fun getTestNameByClearUnnecessaryString(expression: JSLiteralExpression): String
     val testName = expression.stringValue
 
     if (testName != null) {
-        return testName
+        return testName.trim().replace("  +".toRegex(), " ")
     }
 
     val paramSourceCode = expression.text


### PR DESCRIPTION
This PR should enable matching of tests with trailing spaces. And when there are multiple spaces in the middle.

I noticed there seems to be some kind of handling for this already by @BlackHole1 but that part won't run if the test name is a stringValue of expression. Didn't know if some of the logic could be shared, but this seems to work fine.