### PR TITLE
Use full file path when file is not inside of basePath

### DIFF
--- a/src/main/kotlin/no/eirikb/avatest/actions/AvaJavaScriptTestRunnerRunConfigurationGenerator.kt
+++ b/src/main/kotlin/no/eirikb/avatest/actions/AvaJavaScriptTestRunnerRunConfigurationGenerator.kt
@@ -84,7 +84,11 @@ class AvaJavaScriptTestRunnerRunConfigurationGenerator : AnAction() {
             val filePath = currentFile.path
             val fileName = Paths.get(filePath).fileName.toString()
             val basePath = project.basePath
-            val relPath = if (basePath == null) fileName else currentFile.path.substring(basePath.length + 1)
+            val relPath = if (basePath == null || !filePath.startsWith(basePath)) {
+                filePath
+            } else {
+                filePath.substring(basePath.length + 1)
+            }
 
             val configuration = if (AppSettingsState.instance.selectedCommand) {
                 this.createNodeJsRunConfiguration(project, fileName, relPath, testName)


### PR DESCRIPTION
A quick fix for situations when trying to test a file that is outside the project base path (e.g. when directory is attached as a project module).

This is still wrong (`startsWith` check will fail if file is in `base-path-kind-of/...`) but it covers more edge cases than before :)

Also I replaced fileName with filePath (guessing that was a typo).

Btw originally forked to bump supported version to 252, seems to be working just fine otherwise. Thank you for the plugin!